### PR TITLE
fix websocket disposal logic

### DIFF
--- a/osu.Game/Online/WebSockets/WebSocketClient.cs
+++ b/osu.Game/Online/WebSockets/WebSocketClient.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Online.WebSockets
         {
             if (cts == null || process == null || stopping)
                 return;
+
             stopping = true;
 
             await OnClosing(token).ConfigureAwait(false);
@@ -92,6 +93,7 @@ namespace osu.Game.Online.WebSockets
             // See also: https://mcguirev10.com/2019/08/17/how-to-close-websocket-correctly.html
             if (socket.State == WebSocketState.Closed || socket.State == WebSocketState.CloseSent || socket.State == WebSocketState.Aborted)
                 return Task.CompletedTask;
+
             return socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, token);
         }
 

--- a/osu.Game/Online/WebSockets/WebSocketServer.cs
+++ b/osu.Game/Online/WebSockets/WebSocketServer.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Online.WebSockets
         {
             if (stopping || listener == null || process == null || cts == null)
                 return;
+
             stopping = true;
 
             try
@@ -121,7 +122,7 @@ namespace osu.Game.Online.WebSockets
                 // An HttpListenerException with the error code 995 (ERROR_OPERATION_ABORTED) is thrown
                 // when we call HttpListener.Stop on another thread while HttpListener.GetContextAsync is
                 // blocking in this thread. It is safe to ignore.
-                if (!(ex is HttpListenerException hx && hx.ErrorCode == 995 || ex is ObjectDisposedException))
+                if (!((ex is HttpListenerException hx && hx.ErrorCode == 995) || ex is ObjectDisposedException))
                 {
                     throw;
                 }


### PR DESCRIPTION
prevent calling start twice, prevent calling stop twice

Moved server cancel before listener.Stop to prevent a connection happening just on close that would then start a whole websocket connection first

Also added token cancel handlers between the async awaits

Removed some unused code and made websocket close only call when a close is neccessary